### PR TITLE
corrected capitalization in treep argument

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ using `git clone` or `treep`:
     pip3 install treep
     cd ~/devel
     git clone git@github.com:machines-in-motion/treep_machines_in_motion.git
-    treep --clone IMU_CORE
+    treep --clone imu_core
     ```
 
 2. use `git clone`  


### PR DESCRIPTION
## Description

"IMU_CORE" was changed into "imu_core" in the command.


## How I Tested

Treep doesn't recognize "IMU_CORE" as a repo and is not able to clone it, but it does recognize "imu_core" and is able to clone it.


## I fulfilled the following requirements

- [ x ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ x ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ x ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
